### PR TITLE
Fix Accessed None On Clients

### DIFF
--- a/UTSAccuBeta4_2/Classes/UTSProjectileSN.uc
+++ b/UTSAccuBeta4_2/Classes/UTSProjectileSN.uc
@@ -19,4 +19,5 @@ simulated event Actor SpawnNotification(Actor A)
 defaultproperties
 {
    ActorClass=class'Projectile'
+   RemoteRole=ROLE_None
 }


### PR DESCRIPTION
Clients dont get the UTSDamageMut replicated to them, so UTSProjectileSN doesnt need to be replicated to them either.